### PR TITLE
Scale kafka

### DIFF
--- a/consumer/consumer.js
+++ b/consumer/consumer.js
@@ -1,7 +1,7 @@
 const writeToDB = require('./writeToDB');
 const { Consumer } = require('sinek');
 const kafkaConfig = require('./kafkaConfig');
-const consumer = new Consumer('test', kafkaConfig);
+const consumer = new Consumer('events', kafkaConfig);
 const withBackpressure = true;
 
 consumer.connect(withBackpressure).then(_ => {

--- a/consumer/kafkaConfig.js
+++ b/consumer/kafkaConfig.js
@@ -1,12 +1,12 @@
 const kafkaConfig = {
-  kafkaHost: "kafka:29092",
+  kafkaHost: "kafka-1:29092,kafka-2:29092,kafka-3:29092",
   logger: {
       debug: msg => console.log(msg),
       info: msg => console.log(msg),
       warn: msg => console.log(msg),
       error: msg => console.log(msg)
   },
-  groupId: "test-group",
+  groupId: "chronos",
   clientName: "chronos-kafka",
   workerPerPartition: 1,
   options: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,38 +42,38 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
-  # timescale:
-  #     image: 'timescale/timescaledb:latest-pg10'
-  #     ports:
-  #       - "5432:5432"
-  #     environment:
-  #       - POSTGRES_DB=chronos_ts
-  #       - POSTGRES_USER=postgres
-  #       - POSTGRES_PASSWORD=postgres_password
-  #     volumes:
-  #       - ./db/setup_timescale.sql:/docker-entrypoint-initdb.d/setup_timescale.sql
-  #       - ./db/postgres:/var/lib/postgresql/data
-  #
-  # api:
-  #   build:
-  #     dockerfile: Dockerfile.dev
-  #     context: ./server
-  #   volumes:
-  #     - /app/node_modules
-  #     - ./server:/app
-  #   ports:
-  #     - "3000:3000"
-  #
-  # consumer:
-  #   environment:
-  #     - PGUSER=postgres
-  #     - PGHOST=timescale
-  #     - PGDATABASE=postgres
-  #     - PGPASSWORD=postgres_password
-  #     - PGPORT=5432
-  #   build:
-  #     dockerfile: Dockerfile.dev
-  #     context: ./consumer
-  #   volumes:
-  #     - /app/node_modules
-  #     - ./consumer:/app
+  timescale:
+      image: 'timescale/timescaledb:latest-pg10'
+      ports:
+        - "5432:5432"
+      environment:
+        - POSTGRES_DB=chronos_ts
+        - POSTGRES_USER=postgres
+        - POSTGRES_PASSWORD=postgres_password
+      volumes:
+        - ./db/setup_timescale.sql:/docker-entrypoint-initdb.d/setup_timescale.sql
+        - ./db/postgres:/var/lib/postgresql/data
+
+  api:
+    build:
+      dockerfile: Dockerfile.dev
+      context: ./server
+    volumes:
+      - /app/node_modules
+      - ./server:/app
+    ports:
+      - "3000:3000"
+
+  consumer:
+    environment:
+      - PGUSER=postgres
+      - PGHOST=timescale
+      - PGDATABASE=postgres
+      - PGPASSWORD=postgres_password
+      - PGPORT=5432
+    build:
+      dockerfile: Dockerfile.dev
+      context: ./consumer
+    volumes:
+      - /app/node_modules
+      - ./consumer:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,73 +2,78 @@ version: '2'
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:latest
-    network_mode: host
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka-1:
     image: confluentinc/cp-kafka:latest
-    network_mode: host
     depends_on:
       - zookeeper
     environment:
       KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:19092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-1:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
   kafka-2:
     image: confluentinc/cp-kafka:latest
-    network_mode: host
     depends_on:
       - zookeeper
     environment:
       KAFKA_BROKER_ID: 2
-      KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:29092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-2:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
   kafka-3:
     image: confluentinc/cp-kafka:latest
-    network_mode: host
     depends_on:
       - zookeeper
     environment:
       KAFKA_BROKER_ID: 3
-      KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:39092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-3:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
-  timescale:
-      image: 'timescale/timescaledb:latest-pg10'
-      ports:
-        - "5432:5432"
-      environment:
-        - POSTGRES_DB=chronos_ts
-        - POSTGRES_USER=postgres
-        - POSTGRES_PASSWORD=postgres_password
-      volumes:
-        - ./db/setup_timescale.sql:/docker-entrypoint-initdb.d/setup_timescale.sql
-        - ./db/postgres:/var/lib/postgresql/data
-
-  api:
-    build:
-      dockerfile: Dockerfile.dev
-      context: ./server
-    volumes:
-      - /app/node_modules
-      - ./server:/app
-    ports:
-      - "3000:3000"
-
-  consumer:
-    environment:
-      - PGUSER=postgres
-      - PGHOST=timescale
-      - PGDATABASE=postgres
-      - PGPASSWORD=postgres_password
-      - PGPORT=5432
-    build:
-      dockerfile: Dockerfile.dev
-      context: ./consumer
-    volumes:
-      - /app/node_modules
-      - ./consumer:/app
+  # timescale:
+  #     image: 'timescale/timescaledb:latest-pg10'
+  #     ports:
+  #       - "5432:5432"
+  #     environment:
+  #       - POSTGRES_DB=chronos_ts
+  #       - POSTGRES_USER=postgres
+  #       - POSTGRES_PASSWORD=postgres_password
+  #     volumes:
+  #       - ./db/setup_timescale.sql:/docker-entrypoint-initdb.d/setup_timescale.sql
+  #       - ./db/postgres:/var/lib/postgresql/data
+  #
+  # api:
+  #   build:
+  #     dockerfile: Dockerfile.dev
+  #     context: ./server
+  #   volumes:
+  #     - /app/node_modules
+  #     - ./server:/app
+  #   ports:
+  #     - "3000:3000"
+  #
+  # consumer:
+  #   environment:
+  #     - PGUSER=postgres
+  #     - PGHOST=timescale
+  #     - PGDATABASE=postgres
+  #     - PGPASSWORD=postgres_password
+  #     - PGPORT=5432
+  #   build:
+  #     dockerfile: Dockerfile.dev
+  #     context: ./consumer
+  #   volumes:
+  #     - /app/node_modules
+  #     - ./consumer:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,40 +2,40 @@ version: '2'
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:latest
+    network_mode: host
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
 
-  kafka:
-    # "`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-
-    # An important note about accessing Kafka from clients on other machines:
-    # -----------------------------------------------------------------------
-    #
-    # The config used here exposes port 9092 for _external_ connections to the broker
-    # i.e. those from _outside_ the docker network. This could be from the host machine
-    # running docker, or maybe further afield if you've got a more complicated setup.
-    # If the latter is true, you will need to change the value 'localhost' in
-    # KAFKA_ADVERTISED_LISTENERS to one that is resolvable to the docker host from those
-    # remote clients
-    #
-    # For connections _internal_ to the docker network, such as from other services
-    # and components, use kafka:29092.
-    #
-    # See https://rmoff.net/2018/08/02/kafka-listeners-explained/ for details
-    # "`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-
-    #
+  kafka-1:
     image: confluentinc/cp-kafka:latest
+    network_mode: host
     depends_on:
       - zookeeper
-    ports:
-      - 9092:9092
     environment:
       KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:19092
+
+  kafka-2:
+    image: confluentinc/cp-kafka:latest
+    network_mode: host
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 2
+      KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:29092
+
+  kafka-3:
+    image: confluentinc/cp-kafka:latest
+    network_mode: host
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 3
+      KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:39092
 
   timescale:
       image: 'timescale/timescaledb:latest-pg10'

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -4,9 +4,9 @@ const router = express.Router();
 /* Kafka Producer Configuration */
 const { Producer } = require('sinek');
 const kafkaConfig = require('./kafkaConfig');
-const partitions = 1;
+const partitions = 6;
 const compressionType = 0; // no compression
-const topic = 'test';
+const topic = 'events';
 const producer = new Producer(kafkaConfig, topic, partitions);
 
 producer.connect();

--- a/server/routes/kafkaConfig.js
+++ b/server/routes/kafkaConfig.js
@@ -1,12 +1,12 @@
 const kafkaConfig = {
-  kafkaHost: "kafka:29092",
+  kafkaHost: "kafka-1:29092,kafka-2:29092,kafka-3:29092",
   logger: {
       debug: msg => console.log(msg),
       info: msg => console.log(msg),
       warn: msg => console.log(msg),
       error: msg => console.log(msg)
   },
-  groupId: "test-group",
+  groupId: "chronos",
   clientName: "chronos-kafka",
   workerPerPartition: 1,
   options: {


### PR DESCRIPTION
This branch scaled the number of Kafka brokers to 3 and was successfully tested to make sure data could be sent from the browser into TimescaleDB.